### PR TITLE
Suggestion resolve no longer cancel on search query change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Guide: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+### Fixed
+
+ - Suggestion resolve no longer cancel on search query change.
+
 ## [1.0.0-beta.21] - 2021-12-22
 
 ## Internal

--- a/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
@@ -247,7 +247,7 @@ public class SearchEngine: AbstractSearchEngine {
         
         switch queryValue {
         case .string(let query):
-            if coreResponse.request.query != query, coreResponse.request.endpoint != "suggest" {
+            if coreResponse.request.query != query {
                 return nil
             }
         case .category:

--- a/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
+++ b/Sources/MapboxSearch/PublicAPI/Engine/SearchEngine.swift
@@ -247,7 +247,7 @@ public class SearchEngine: AbstractSearchEngine {
         
         switch queryValue {
         case .string(let query):
-            if coreResponse.request.query != query {
+            if coreResponse.request.query != query, coreResponse.request.endpoint != "suggest" {
                 return nil
             }
         case .category:

--- a/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
+++ b/Sources/MapboxSearch/PublicAPI/MapboxSearchVersion.swift
@@ -1,2 +1,2 @@
 /// Mapbox Search SDK version variable
-public let mapboxSearchSDKVersion = "1.0.0-beta.20"
+public let mapboxSearchSDKVersion = "1.0.0-beta.21"

--- a/Sources/MapboxSearchUI/MapboxSearchController.swift
+++ b/Sources/MapboxSearchUI/MapboxSearchController.swift
@@ -241,9 +241,9 @@ public class MapboxSearchController: UIViewController {
     func updateTableStateUI() {
         switch tableState {
         case .history:
+            searchSuggestionsSource.reset() // Reset SearchResults cache to avoid outdated results during next search
             tableController.tableView.dataSource = historySource
             tableController.tableView.delegate = historySource
-            searchSuggestionsSource.reset() // Reset SearchResults cache to avoid outdated results during next search
             tableController.tableView.tableFooterView = UIView()
         case .searchResult:
             tableController.tableView.dataSource = searchSuggestionsSource
@@ -327,8 +327,8 @@ public class MapboxSearchController: UIViewController {
     }
     
     func presentSearchError(_ error: SearchError) {
-        searchErrorView.setError(error)
         searchSuggestionsSource.reset()
+        searchErrorView.setError(error)
         tableController.tableView.tableFooterView = searchErrorView
         tableController.tableView.reloadData()
         mapboxPanelController?.panelNavigationController.popToRootViewController(animated: true)

--- a/Sources/MapboxSearchUI/SearchSuggestionsTableSource.swift
+++ b/Sources/MapboxSearchUI/SearchSuggestionsTableSource.swift
@@ -30,6 +30,7 @@ class SearchSuggestionsTableSource: NSObject, UITableViewDataSource, UITableView
     
     func reset() {
         suggestions = []
+        tableView?.reloadData()
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Tests/MapboxSearchTests/SearchEngineTests.swift
+++ b/Tests/MapboxSearchTests/SearchEngineTests.swift
@@ -29,7 +29,7 @@ class SearchEngineTests: XCTestCase {
         if case .success(let results) = response.process() {
             XCTAssertEqual(results.suggestions.map({ $0.id }), searchEngine.suggestions.map({ $0.id }))
         } else {
-            fatalError("impossible")
+            XCTFail("impossible")
         }
     }
     
@@ -47,7 +47,7 @@ class SearchEngineTests: XCTestCase {
         if case .success(let results) = response.process() {
             XCTAssertEqual(results.suggestions.map({ $0.id }), searchEngine.suggestions.map({ $0.id }))
         } else {
-            fatalError("impossible")
+            XCTFail("impossible")
         }
     }
     
@@ -63,7 +63,7 @@ class SearchEngineTests: XCTestCase {
             if case .success(let reverseGeocodingResults) = result {
                 XCTAssertEqual(results.map({ $0.id }), reverseGeocodingResults.map({ $0.id }))
             } else {
-                fatalError("impossible")
+                XCTFail("impossible")
             }
             expectation.fulfill()
         }
@@ -83,7 +83,7 @@ class SearchEngineTests: XCTestCase {
         XCTAssertEqual([], searchEngine.suggestions.map({ $0.id }))
     }
     
-    func testIgnoreResultsForOutdatedSearchQuerry() throws {
+    func testIgnoreResultsForOutdatedSearchQuery() throws {
         let searchEngine = SearchEngine(accessToken: "mapbox-access-token", serviceProvider: provider, locationProvider: DefaultLocationProvider())
         searchEngine.delegate = delegate
         let engine = try XCTUnwrap(searchEngine.engine as? CoreSearchEngineStub)
@@ -97,7 +97,7 @@ class SearchEngineTests: XCTestCase {
         if case .success(let results) = response.process() {
             XCTAssertEqual(results.suggestions.map({ $0.id }), searchEngine.suggestions.map({ $0.id }))
         } else {
-            fatalError("impossible")
+            XCTFail("impossible")
         }
         
         engine.searchResponse = CoreSearchResponseStub.successSample(options: .sample2, results: [])
@@ -109,7 +109,7 @@ class SearchEngineTests: XCTestCase {
         if case .success(let results) = response.process() {
             XCTAssertEqual(results.suggestions.map({ $0.id }), searchEngine.suggestions.map({ $0.id }))
         } else {
-            fatalError("impossible")
+            XCTFail("impossible")
         }
     }
     
@@ -128,7 +128,7 @@ class SearchEngineTests: XCTestCase {
         if case .success(let results) = response.process() {
             XCTAssertEqual(results.suggestions.map({ $0.id }), searchEngine.suggestions.map({ $0.id }))
         } else {
-            fatalError("impossible")
+            XCTFail("impossible")
         }
         
         engine.searchResponse = CoreSearchResponseStub.failureSample
@@ -154,7 +154,7 @@ class SearchEngineTests: XCTestCase {
         if case .success(let results) = response.process() {
             XCTAssertEqual(results.suggestions.map({ $0.id }), searchEngine.suggestions.map({ $0.id }))
         } else {
-            fatalError("impossible")
+            XCTFail("impossible")
         }
         
         let successExpectation = delegate.successExpectation
@@ -187,7 +187,7 @@ class SearchEngineTests: XCTestCase {
         if case .success(let results) = response.process() {
             XCTAssertEqual(results.suggestions.map({ $0.id }), searchEngine.suggestions.map({ $0.id }))
         } else {
-            fatalError("impossible")
+            XCTFail("impossible")
         }
         
         let successExpectation = delegate.successExpectation
@@ -341,7 +341,7 @@ class SearchEngineTests: XCTestCase {
             if case .failure(let searchError) = result {
                 error = searchError
             } else {
-                fatalError("impossible")
+                XCTFail("impossible")
             }
             expectation.fulfill()
         }


### PR DESCRIPTION
### Description
Suggestion resolve no longer cancel on search query change

### Checklist
- [x] Update `CHANGELOG`
