### PR TITLE
Cancelable renamed into SearchCancelable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Guide: https://keepachangelog.com/en/1.0.0/
 ### Fixed
 
  - Suggestion resolve no longer cancel on search query change.
+ - Cancelable renamed into SearchCancelable to prevent naming conflicts with Maps SDK.
 
 ## [1.0.0-beta.21] - 2021-12-22
 

--- a/MapboxSearch.xcodeproj/project.pbxproj
+++ b/MapboxSearch.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		F9201EE0253F1C6F002D141B /* CategorySuggestionsNavigationIntegrationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9201EDF253F1C6F002D141B /* CategorySuggestionsNavigationIntegrationTestCase.swift */; };
 		F9274FEB2732BF0E00708F37 /* SearchTileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9274FEA2732BF0E00708F37 /* SearchTileStore.swift */; };
 		F9274FED2733D29700708F37 /* SearchOfflineManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9274FEC2733D29700708F37 /* SearchOfflineManager.swift */; };
-		F9274FEF27393A7E00708F37 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9274FEE27393A7E00708F37 /* Cancelable.swift */; };
+		F9274FEF27393A7E00708F37 /* SearchCancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9274FEE27393A7E00708F37 /* SearchCancelable.swift */; };
 		F9274FF227394AE600708F37 /* TileRegionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9274FF127394AE600708F37 /* TileRegionError.swift */; };
 		F9274FF5273AA79700708F37 /* OfflineIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9274FF3273AA72800708F37 /* OfflineIntegrationTests.swift */; };
 		F9274FF7273AAE7200708F37 /* TileRegionLoadOptions+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9274FF6273AAE7200708F37 /* TileRegionLoadOptions+Search.swift */; };
@@ -442,7 +442,7 @@
 		F9201EDF253F1C6F002D141B /* CategorySuggestionsNavigationIntegrationTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySuggestionsNavigationIntegrationTestCase.swift; sourceTree = "<group>"; };
 		F9274FEA2732BF0E00708F37 /* SearchTileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTileStore.swift; sourceTree = "<group>"; };
 		F9274FEC2733D29700708F37 /* SearchOfflineManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchOfflineManager.swift; sourceTree = "<group>"; };
-		F9274FEE27393A7E00708F37 /* Cancelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cancelable.swift; sourceTree = "<group>"; };
+		F9274FEE27393A7E00708F37 /* SearchCancelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCancelable.swift; sourceTree = "<group>"; };
 		F9274FF127394AE600708F37 /* TileRegionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TileRegionError.swift; sourceTree = "<group>"; };
 		F9274FF3273AA72800708F37 /* OfflineIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineIntegrationTests.swift; sourceTree = "<group>"; };
 		F9274FF6273AAE7200708F37 /* TileRegionLoadOptions+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TileRegionLoadOptions+Search.swift"; sourceTree = "<group>"; };
@@ -869,7 +869,7 @@
 		F9274FF027394ABF00708F37 /* Offline */ = {
 			isa = PBXGroup;
 			children = (
-				F9274FEE27393A7E00708F37 /* Cancelable.swift */,
+				F9274FEE27393A7E00708F37 /* SearchCancelable.swift */,
 				F9274FEC2733D29700708F37 /* SearchOfflineManager.swift */,
 				F9274FF127394AE600708F37 /* TileRegionError.swift */,
 				F9274FEA2732BF0E00708F37 /* SearchTileStore.swift */,
@@ -1899,7 +1899,7 @@
 				F9A0B8392562845400CAD907 /* SearchNavigationProfile.swift in Sources */,
 				F9274FF227394AE600708F37 /* TileRegionError.swift in Sources */,
 				FE1064F525B9A1C9007837BC /* NavigationOptions.swift in Sources */,
-				F9274FEF27393A7E00708F37 /* Cancelable.swift in Sources */,
+				F9274FEF27393A7E00708F37 /* SearchCancelable.swift in Sources */,
 				FE4D4BCA25CAD6810039F933 /* SearchAddressType.swift in Sources */,
 				F9F5D75E256D0393007E32BE /* SearchResponse.swift in Sources */,
 				F931B35225A32CC400AA1674 /* SearchQuerySuggestion.swift in Sources */,

--- a/Sources/MapboxSearch/PublicAPI/Offline/SearchCancelable.swift
+++ b/Sources/MapboxSearch/PublicAPI/Offline/SearchCancelable.swift
@@ -2,11 +2,11 @@ import Foundation
 
 /// A type that conforms to `Cancelable` typically represents a long
 /// running operation that can be canceled.
-public protocol Cancelable: AnyObject {
+public protocol SearchCancelable: AnyObject {
     func cancel()
 }
 
-internal final class CommonCancelableWrapper: Cancelable {
+internal final class CommonCancelableWrapper: SearchCancelable {
     private let cancelable: MapboxCommon.Cancelable
 
     internal init(_ cancelable: MapboxCommon.Cancelable) {

--- a/Sources/MapboxSearch/PublicAPI/Offline/SearchTileStore.swift
+++ b/Sources/MapboxSearch/PublicAPI/Offline/SearchTileStore.swift
@@ -89,7 +89,7 @@ public class SearchTileStore {
     ///         of the loading operation. Any `Result` error could be of type
     ///         `TileRegionError`.
     /// - Returns: A `Cancelable` object to cancel the load request
-    public func loadTileRegion(id: String, options: MapboxCommon.TileRegionLoadOptions, progress: MapboxCommon.TileRegionLoadProgressCallback? = nil, completion: ((Result<MapboxCommon.TileRegion, TileRegionError>) -> Void)?) -> Cancelable {
+    public func loadTileRegion(id: String, options: MapboxCommon.TileRegionLoadOptions, progress: MapboxCommon.TileRegionLoadProgressCallback? = nil, completion: ((Result<MapboxCommon.TileRegion, TileRegionError>) -> Void)?) -> SearchCancelable {
         if let progress = progress {
             let cancelable = commonTileStore.__loadTileRegion(forId: id, loadOptions: options, onProgress: progress) { expected in
                 completion?(makeResult(expected: expected, fallbackError: TileRegionError.other("Unexpected")))

--- a/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
+++ b/Tests/MapboxSearchIntegrationTests/OfflineIntegrationTests.swift
@@ -38,7 +38,7 @@ class OfflineIntegrationTests: MockServerTestCase {
         
     }
     
-    func loadData(completion: @escaping (Result<MapboxCommon.TileRegion, MapboxSearch.TileRegionError>) -> ()) -> MapboxSearch.Cancelable {
+    func loadData(completion: @escaping (Result<MapboxCommon.TileRegion, MapboxSearch.TileRegionError>) -> ()) -> SearchCancelable {
         let descriptor = SearchOfflineManager.createDefaultTilesetDescriptor()
         let dcLocationValue = NSValue(cgPoint: dcLocation)
         let options = MapboxCommon.TileRegionLoadOptions.build(geometry: Geometry(point: dcLocationValue), descriptors: [descriptor], acceptExpired: true)!


### PR DESCRIPTION
### Description
Cancelable renamed into SearchCancelable to prevent naming conflicts with Maps SDK.

### Checklist
- [x] Update `CHANGELOG`
