### PR TITLE
RecordsProviderInteractor batch add() and delete() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Guide: https://keepachangelog.com/en/1.0.0/
 ### Added
 
 - Missing result feedback type.
+- RecordsProviderInteractor.add(records: [IndexableRecord])  method for batch adding user records.
+- RecordsProviderInteractor.delete(identifiers: [String])  method for batch removing user records.
 
 ### Fixed
 

--- a/Sources/MapboxSearch/InternalAPI/CoreUserRecordsLayerProtocol.swift
+++ b/Sources/MapboxSearch/InternalAPI/CoreUserRecordsLayerProtocol.swift
@@ -12,6 +12,8 @@ protocol CoreUserRecordsLayerProtocol {
 
     @discardableResult
     func remove(forId id: String) throws -> Bool
+    
+    func removeMulti(forIds: [String]) throws
 
     func clear() throws
 

--- a/Sources/MapboxSearch/InternalAPI/RecordsProviderInteractorNativeCore.swift
+++ b/Sources/MapboxSearch/InternalAPI/RecordsProviderInteractorNativeCore.swift
@@ -15,6 +15,15 @@ class RecordsProviderInteractorNativeCore: RecordsProviderInteractor {
         }
     }
     
+    func add(records: [IndexableRecord]) {
+        do {
+            let coreRecords = records.map { $0.coreUserRecord() }
+            try userRecordsLayer.addMulti(for: coreRecords)
+        } catch {
+            _Logger.searchSDK.error("Failed to call \(#function) due to error: \(error)", category: .userRecords)
+        }
+    }
+    
     func update(record: IndexableRecord) {
         do {
             try userRecordsLayer.update(for: record.coreUserRecord())
@@ -30,6 +39,14 @@ class RecordsProviderInteractorNativeCore: RecordsProviderInteractor {
             _Logger.searchSDK.error("Failed to call \(#function) due to error: \(error)", category: .userRecords)
         }
     }
+    func delete(identifiers: [String]) {
+        do {
+            try userRecordsLayer.removeMulti(forIds: identifiers)
+        } catch {
+            _Logger.searchSDK.error("Failed to call \(#function) due to error: \(error)", category: .userRecords)
+        }
+    }
+    
     
     func deleteAll() {
         do {

--- a/Sources/MapboxSearch/PublicAPI/RecordsProviderInteractor.swift
+++ b/Sources/MapboxSearch/PublicAPI/RecordsProviderInteractor.swift
@@ -7,6 +7,10 @@ public protocol RecordsProviderInteractor {
     /// Engine would add it to the search index asap.
     func add(record: IndexableRecord)
     
+    /// Notify about records addition.
+    /// Engine would add it to the search index asap.
+    func add(records: [IndexableRecord])
+    
     /// Notify about record alteration.
     /// Engine would update search index for corresponding identifier asap.
     func update(record: IndexableRecord)
@@ -14,6 +18,10 @@ public protocol RecordsProviderInteractor {
     /// Notify about record deletion.
     /// Engine would drop search index for particular identifier.
     func delete(identifier: String)
+    
+    /// Notify about record deletion.
+    /// Engine would drop search index for  identifiers
+    func delete(identifiers: [String])
     
     /// Notify about database drop.
     /// Engine would drop layer related search indexes.

--- a/Tests/MapboxSearchTests/RecordsProviderInteractorNativeCoreTests.swift
+++ b/Tests/MapboxSearchTests/RecordsProviderInteractorNativeCoreTests.swift
@@ -59,6 +59,27 @@ class RecordsProviderInteractorNativeCoreTests: XCTestCase {
         XCTAssertFalse(interactor.contains(identifier: record.id))
     }
     
+    // swiftlint:disable identifier_name
+    func testInteractorAddDeleteMultiRecords() {
+        let record_1 = IndexableRecordStub()
+        let record_2 = IndexableRecordStub()
+        let record_3 = IndexableRecordStub()
+        interactor.add(records: [record_1, record_2, record_3])
+        
+        XCTAssertEqual(layerStub.records.count, 3)
+        
+        XCTAssert(interactor.contains(identifier: record_1.id))
+        XCTAssert(interactor.contains(identifier: record_2.id))
+        XCTAssert(interactor.contains(identifier: record_3.id))
+        
+        interactor.delete(identifiers: [record_1.id, record_3.id])
+        
+        XCTAssertFalse(interactor.contains(identifier: record_1.id))
+        XCTAssertFalse(interactor.contains(identifier: record_3.id))
+        
+        XCTAssertTrue(interactor.contains(identifier: record_2.id))
+    }
+    
     func testInteractorDeleteAllRecords() {
         for _ in 0..<3 {
             interactor.add(record: IndexableRecordStub())

--- a/Tests/MapboxSearchTests/Stubs&Models/CoreUserRecordsLayerStub.swift
+++ b/Tests/MapboxSearchTests/Stubs&Models/CoreUserRecordsLayerStub.swift
@@ -28,6 +28,11 @@ class CoreUserRecordsLayerStub: CoreUserRecordsLayerProtocol {
         records.removeAll(where: { $0.id == id })
         return true
     }
+    
+    func removeMulti(forIds: [String]) {
+        forIds.forEach { remove(forId: $0) }
+    }
+    
     func clear() {
         records.removeAll()
     }


### PR DESCRIPTION
### Description
- RecordsProviderInteractor.add(records: [IndexableRecord])  method for batch adding user records.
- RecordsProviderInteractor.delete(identifiers: [String])  method for batch removing user records.

### Checklist
- [x] Update `CHANGELOG`
